### PR TITLE
feat: 온보딩 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-query": "^5.64.2",
     "@xstate/react": "^5.0.2",
     "lucide-react": "^0.473.0",
+    "motion": "^12.0.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwindcss": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       lucide-react:
         specifier: ^0.473.0
         version: 0.473.0(react@18.3.1)
+      motion:
+        specifier: ^12.0.6
+        version: 12.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1013,6 +1016,20 @@ packages:
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
 
+  framer-motion@12.0.6:
+    resolution: {integrity: sha512-LmrXbXF6Vv5WCNmb+O/zn891VPZrH7XbsZgRLBROw6kFiP+iTK49gxTv2Ur3F0Tbw6+sy9BVtSqnWfMUpH+6nA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1283,6 +1300,26 @@ packages:
   modern-ahocorasick@1.1.0:
     resolution: {integrity: sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==}
 
+  motion-dom@12.0.0:
+    resolution: {integrity: sha512-CvYd15OeIR6kHgMdonCc1ihsaUG4MYh/wrkz8gZ3hBX/uamyZCXN9S9qJoYF03GqfTt7thTV/dxnHYX4+55vDg==}
+
+  motion-utils@12.0.0:
+    resolution: {integrity: sha512-MNFiBKbbqnmvOjkPyOKgHUp3Q6oiokLkI1bEwm5QA28cxMZrv0CbbBGDNmhF6DIXsi1pCQBSs0dX8xjeER1tmA==}
+
+  motion@12.0.6:
+    resolution: {integrity: sha512-AzCEO0+//mPlcGiL9JaVwjddHY1cbbnvz5upHL0toqQwsPCs+hiKJ0XG5jfG0XwDtBbiSXdEqW/UTmGLwkVQ6A==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1542,6 +1579,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2550,6 +2590,15 @@ snapshots:
 
   flatted@3.3.2: {}
 
+  framer-motion@12.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      motion-dom: 12.0.0
+      motion-utils: 12.0.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   fsevents@2.3.3:
     optional: true
 
@@ -2767,6 +2816,20 @@ snapshots:
 
   modern-ahocorasick@1.1.0: {}
 
+  motion-dom@12.0.0:
+    dependencies:
+      motion-utils: 12.0.0
+
+  motion-utils@12.0.0: {}
+
+  motion@12.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      framer-motion: 12.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   ms@2.1.3: {}
 
   nanoid@3.3.8: {}
@@ -2953,6 +3016,8 @@ snapshots:
   ts-api-utils@2.0.0(typescript@5.6.3):
     dependencies:
       typescript: 5.6.3
+
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:

--- a/src/components/AdmissionYearInput.tsx
+++ b/src/components/AdmissionYearInput.tsx
@@ -42,11 +42,12 @@ const AdmissionYearInput = ({ onNext }: AdmissionYearInputProps) => {
           className="bg-basic-light focus-visible:ring-ring flex w-full items-center justify-between rounded-lg px-4 py-3 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
           onClick={() => setShowDropdown(!showDropdown)}
         >
-          <span
+          <button
+            type="button"
             className={`text-lg font-semibold ${admissionYear ? 'text-primary' : 'text-placeholder'}`}
           >
             {admissionYear ?? '입학년도(학번)'}
-          </span>
+          </button>
           <ChevronDown className="size-4" />
         </div>
         <AnimatePresence>
@@ -69,6 +70,7 @@ const AdmissionYearInput = ({ onNext }: AdmissionYearInputProps) => {
               {admissionYears.map((year) => (
                 <li key={year}>
                   <button
+                    type="button"
                     className="text-list flex w-full items-center justify-between rounded-lg px-4 py-2 text-lg font-semibold hover:bg-gray-100"
                     onClick={() => {
                       handleAdmissionYearSelect(year);

--- a/src/components/AdmissionYearInput.tsx
+++ b/src/components/AdmissionYearInput.tsx
@@ -1,0 +1,103 @@
+import { Check, ChevronDown } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { useEffect, useRef, useState } from 'react';
+
+const admissionYears = [25, 24, 23, 22, 21, 20, 19, 18];
+
+interface AdmissionYearInputProps {
+  onNext: (admissionYear: number) => void;
+}
+
+const AdmissionYearInput = ({ onNext }: AdmissionYearInputProps) => {
+  const [admissionYear, setAdmissionYear] = useState<number>();
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [showLabel, setShowLabel] = useState(false);
+  const dropDownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropDownRef.current && !dropDownRef.current.contains(event.target as Node)) {
+        setShowDropdown(false);
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  });
+
+  const handleAdmissionYearSelect = (year: number) => {
+    setAdmissionYear(year);
+    setShowDropdown(false);
+
+    // 라벨 보이기
+    setShowLabel(true);
+    // 다음 단계로 넘어가기
+    onNext(year);
+  };
+
+  return (
+    <motion.div
+      initial={{
+        opacity: 0,
+        y: -20,
+      }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{
+        duration: 0.3,
+        ease: 'easeOut',
+      }}
+    >
+      {showLabel && <label className="mb-1.5 block text-sm">입학년도(학번)</label>}
+      <div className="relative" ref={dropDownRef}>
+        <div
+          className="bg-basic-light focus-visible:ring-ring flex w-full items-center justify-between rounded-lg px-4 py-3 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
+          onClick={() => setShowDropdown(!showDropdown)}
+        >
+          <span
+            className={`text-lg font-semibold ${admissionYear ? 'text-primary' : 'text-placeholder'}`}
+          >
+            {admissionYear ?? '입학년도(학번)'}
+          </span>
+          <ChevronDown className="size-4" />
+        </div>
+        <AnimatePresence>
+          {showDropdown && (
+            <motion.ul
+              className="bg-basic-light absolute z-10 mt-2 max-h-44 w-full overflow-y-auto rounded-lg border border-gray-200 shadow-sm"
+              initial={{ opacity: 0, y: -10 }}
+              animate={{
+                opacity: 1,
+                y: 0,
+              }}
+              exit={{
+                opacity: 0,
+                y: -10,
+              }}
+              transition={{
+                duration: 0.2,
+              }}
+            >
+              {admissionYears.map((year) => (
+                <li key={year}>
+                  <button
+                    className="text-list flex w-full items-center justify-between rounded-lg px-4 py-2 text-lg font-semibold hover:bg-gray-100"
+                    onClick={() => {
+                      handleAdmissionYearSelect(year);
+                    }}
+                  >
+                    {year}
+                    {admissionYear === year && <Check className="size-4 text-green-500" />}
+                  </button>
+                </li>
+              ))}
+            </motion.ul>
+          )}
+        </AnimatePresence>
+      </div>
+    </motion.div>
+  );
+};
+
+export default AdmissionYearInput;

--- a/src/components/AdmissionYearInput.tsx
+++ b/src/components/AdmissionYearInput.tsx
@@ -1,6 +1,7 @@
 import { Check, ChevronDown } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
+import { useDropdown } from '../hooks/useDropDown';
 
 const admissionYears = [25, 24, 23, 22, 21, 20, 19, 18];
 
@@ -10,22 +11,8 @@ interface AdmissionYearInputProps {
 
 const AdmissionYearInput = ({ onNext }: AdmissionYearInputProps) => {
   const [admissionYear, setAdmissionYear] = useState<number>();
-  const [showDropdown, setShowDropdown] = useState(false);
   const [showLabel, setShowLabel] = useState(false);
-  const dropDownRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropDownRef.current && !dropDownRef.current.contains(event.target as Node)) {
-        setShowDropdown(false);
-      }
-    };
-
-    document.addEventListener('click', handleClickOutside);
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  });
+  const [showDropdown, setShowDropdown, dropDownRef] = useDropdown();
 
   const handleAdmissionYearSelect = (year: number) => {
     setAdmissionYear(year);

--- a/src/components/AdmissionYearInput.tsx
+++ b/src/components/AdmissionYearInput.tsx
@@ -53,7 +53,7 @@ const AdmissionYearInput = ({ onNext }: AdmissionYearInputProps) => {
         <AnimatePresence>
           {showDropdown && (
             <motion.ul
-              className="bg-basic-light absolute z-10 mt-2 max-h-44 w-full overflow-y-auto rounded-lg border border-gray-200 shadow-sm"
+              className="bg-basic-light absolute z-10 mt-2 max-h-55 w-full overflow-y-auto rounded-lg border border-gray-200 shadow-sm"
               initial={{ opacity: 0, y: -10 }}
               animate={{
                 opacity: 1,

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -1,0 +1,34 @@
+import { useActivity } from '@stackflow/react';
+import { ChevronLeft } from 'lucide-react';
+import { useFlow } from '../stackflow';
+import ProgressBar from './ProgressBar';
+
+interface AppBarProps {
+  progress: number; // 0 to 100
+}
+
+const AppBar = ({ progress }: AppBarProps) => {
+  const activity = useActivity();
+  const { pop } = useFlow();
+
+  const handleClickBackButton = () => {
+    pop();
+  };
+
+  return (
+    <div className="flex items-center gap-4 px-6">
+      <button
+        onClick={handleClickBackButton}
+        className={`flex size-6 ${activity.isRoot ? 'invisible' : ''}`}
+      >
+        <ChevronLeft />
+      </button>
+      <div className="flex-1">
+        <ProgressBar width={progress} />
+      </div>
+      <div className="size-6" aria-hidden="true" />
+    </div>
+  );
+};
+
+export default AppBar;

--- a/src/components/ChapelInput.tsx
+++ b/src/components/ChapelInput.tsx
@@ -2,8 +2,17 @@ import { CircleCheck } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useState } from 'react';
 
-const ChapelInput = () => {
+interface ChapelInputProps {
+  onNext: (chapel: boolean) => void;
+}
+
+const ChapelInput = ({ onNext }: ChapelInputProps) => {
   const [chapel, setChapel] = useState(true);
+
+  const handleClickChapel = () => {
+    setChapel(!chapel);
+    onNext(!chapel);
+  };
 
   return (
     <motion.div
@@ -20,7 +29,7 @@ const ChapelInput = () => {
       <label className="mb-1.5 block text-sm">채플 수강 여부</label>
       <div
         className="bg-basic-light focus-visible:ring-ring flex w-full items-center justify-between rounded-lg px-4 py-3 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
-        onClick={() => setChapel(!chapel)}
+        onClick={handleClickChapel}
       >
         <button type="button" className="text-primary text-lg font-semibold">
           {chapel ? '채플 수강' : '채플 미수강'}

--- a/src/components/ChapelInput.tsx
+++ b/src/components/ChapelInput.tsx
@@ -1,0 +1,34 @@
+import { CircleCheck } from 'lucide-react';
+import { motion } from 'motion/react';
+import { useState } from 'react';
+
+const ChapelInput = () => {
+  const [chapel, setChapel] = useState(true);
+
+  return (
+    <motion.div
+      initial={{
+        opacity: 0,
+        y: -20,
+      }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{
+        duration: 0.3,
+        ease: 'easeOut',
+      }}
+    >
+      <label className="mb-1.5 block text-sm">채플 수강 여부</label>
+      <div
+        className="bg-basic-light focus-visible:ring-ring flex w-full items-center justify-between rounded-lg px-4 py-3 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
+        onClick={() => setChapel(!chapel)}
+      >
+        <button type="button" className="text-primary text-lg font-semibold">
+          {chapel ? '채플 수강' : '채플 미수강'}
+        </button>
+        <CircleCheck className={`size-6 ${chapel ? 'text-primary' : 'text-placeholder'}`} />
+      </div>
+    </motion.div>
+  );
+};
+
+export default ChapelInput;

--- a/src/components/DepartmentInput.tsx
+++ b/src/components/DepartmentInput.tsx
@@ -75,6 +75,7 @@ const DepartmentInput = ({ onNext }: DepartmentInputProps) => {
             {matchingDepartments.map((dept, index) => (
               <li key={index}>
                 <button
+                  type="button"
                   className="text-list flex w-full items-center justify-between rounded-lg px-4 py-2 text-lg font-semibold hover:bg-gray-100"
                   onClick={() => handleDepartmentSelect(dept)}
                 >

--- a/src/components/DepartmentInput.tsx
+++ b/src/components/DepartmentInput.tsx
@@ -1,5 +1,5 @@
 import { Check } from 'lucide-react';
-import { motion } from 'motion/react';
+import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 
 const allDepartments = [
@@ -43,13 +43,12 @@ const DepartmentInput = ({ onNext }: DepartmentInputProps) => {
 
     // 라벨 보이기
     setShowLabel(true);
-
     // 다음 단계로 넘어가기
     onNext(department);
   };
 
   return (
-    <>
+    <div className="relative">
       {showLabel && <label className="mb-1.5 block text-sm">학과</label>}
       <input
         type="text"
@@ -58,33 +57,36 @@ const DepartmentInput = ({ onNext }: DepartmentInputProps) => {
         className="bg-basic-light text-primary focus-visible:ring-ring w-full rounded-lg px-4 py-3 text-lg font-semibold focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
         placeholder="학과"
       />
-      {matchingDepartments.length > 0 && (
-        <motion.ul
-          initial={{
-            opacity: 0,
-            y: -10,
-          }}
-          animate={{
-            opacity: 1,
-            y: 0,
-          }}
-          transition={{ duration: 0.3 }}
-          className="bg-basic-light mt-2 rounded-lg border border-gray-200 shadow-sm"
-        >
-          {matchingDepartments.map((dept, index) => (
-            <li key={index}>
-              <button
-                className="text-list flex w-full items-center justify-between rounded-lg px-4 py-3 text-lg font-semibold hover:bg-gray-100"
-                onClick={() => handleDepartmentSelect(dept)}
-              >
-                {dept}
-                {department === dept && <Check className="size-4 text-green-500" />}
-              </button>
-            </li>
-          ))}
-        </motion.ul>
-      )}
-    </>
+      <AnimatePresence>
+        {matchingDepartments.length > 0 && (
+          <motion.ul
+            initial={{
+              opacity: 0,
+              y: -10,
+            }}
+            animate={{
+              opacity: 1,
+              y: 0,
+            }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.2 }}
+            className="bg-basic-light absolute z-10 mt-2 w-full rounded-lg border border-gray-200 shadow-sm"
+          >
+            {matchingDepartments.map((dept, index) => (
+              <li key={index}>
+                <button
+                  className="text-list flex w-full items-center justify-between rounded-lg px-4 py-2 text-lg font-semibold hover:bg-gray-100"
+                  onClick={() => handleDepartmentSelect(dept)}
+                >
+                  {dept}
+                  {department === dept && <Check className="size-4 text-green-500" />}
+                </button>
+              </li>
+            ))}
+          </motion.ul>
+        )}
+      </AnimatePresence>
+    </div>
   );
 };
 

--- a/src/components/DepartmentInput.tsx
+++ b/src/components/DepartmentInput.tsx
@@ -1,0 +1,91 @@
+import { Check } from 'lucide-react';
+import { motion } from 'motion/react';
+import { useState } from 'react';
+
+const allDepartments = [
+  '컴퓨터학부',
+  '전자공학과',
+  '기계공학과',
+  '화학공학과',
+  '생명공학과',
+  '수학과',
+  '물리학과',
+  '화학과',
+  '경영학과',
+  '경제학과',
+  '심리학과',
+  '사회학과',
+  '영어영문학과',
+  '국어국문학과',
+  '철학과',
+];
+
+interface DepartmentInputProps {
+  onNext: (department: string) => void;
+}
+
+const DepartmentInput = ({ onNext }: DepartmentInputProps) => {
+  const [department, setDepartment] = useState('');
+  const [matchingDepartments, setMatchingDepartments] = useState<string[]>([]);
+  const [showLabel, setShowLabel] = useState(false);
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value.trim();
+    setDepartment(value);
+
+    const matches = allDepartments.filter((dept) => value !== '' && dept.includes(value));
+    setMatchingDepartments(matches);
+  };
+
+  const handleDepartmentSelect = (department: string) => {
+    setDepartment(department);
+    setMatchingDepartments([]);
+
+    // 라벨 보이기
+    setShowLabel(true);
+
+    // 다음 단계로 넘어가기
+    onNext(department);
+  };
+
+  return (
+    <>
+      {showLabel && <label className="mb-1.5 block text-sm">학과</label>}
+      <input
+        type="text"
+        value={department}
+        onChange={handleInputChange}
+        className="bg-basic-light text-primary focus-visible:ring-ring w-full rounded-lg px-4 py-3 text-lg font-semibold focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
+        placeholder="학과"
+      />
+      {matchingDepartments.length > 0 && (
+        <motion.ul
+          initial={{
+            opacity: 0,
+            y: -10,
+          }}
+          animate={{
+            opacity: 1,
+            y: 0,
+          }}
+          transition={{ duration: 0.3 }}
+          className="bg-basic-light mt-2 rounded-lg border border-gray-200 shadow-sm"
+        >
+          {matchingDepartments.map((dept, index) => (
+            <li key={index}>
+              <button
+                className="text-list flex w-full items-center justify-between rounded-lg px-4 py-3 text-lg font-semibold hover:bg-gray-100"
+                onClick={() => handleDepartmentSelect(dept)}
+              >
+                {dept}
+                {department === dept && <Check className="size-4 text-green-500" />}
+              </button>
+            </li>
+          ))}
+        </motion.ul>
+      )}
+    </>
+  );
+};
+
+export default DepartmentInput;

--- a/src/components/GradeInput.tsx
+++ b/src/components/GradeInput.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown } from 'lucide-react';
+import { Check, ChevronDown, Info } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 import { useDropdown } from '../hooks/useDropDown';
@@ -43,9 +43,12 @@ const GradeInput = ({ onNext }: GradeInputProps) => {
           className="bg-basic-light focus-visible:ring-ring flex w-full items-center justify-between rounded-lg px-4 py-3 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
           onClick={() => setShowDropdown(!showDropdown)}
         >
-          <span className={`text-lg font-semibold ${grade ? 'text-primary' : 'text-placeholder'}`}>
+          <button
+            type="button"
+            className={`text-lg font-semibold ${grade ? 'text-primary' : 'text-placeholder'}`}
+          >
             {grade ?? '학년'}
-          </span>
+          </button>
           <ChevronDown className="size-4" />
         </div>
         <AnimatePresence>
@@ -68,6 +71,7 @@ const GradeInput = ({ onNext }: GradeInputProps) => {
               {grades.map((gradeOption) => (
                 <li key={gradeOption}>
                   <button
+                    type="button"
                     className="text-list flex w-full items-center justify-between rounded-lg px-4 py-2 text-lg font-semibold hover:bg-gray-100"
                     onClick={() => {
                       handleGradeSelect(gradeOption);
@@ -81,6 +85,10 @@ const GradeInput = ({ onNext }: GradeInputProps) => {
             </motion.ul>
           )}
         </AnimatePresence>
+        <div className="text-hint mt-1.5 flex items-center gap-2">
+          <Info className="size-3" />
+          <span className="text-xs">이번 학기에 이수 예정인 학년을 선택해주세요.</span>
+        </div>
       </div>
     </motion.div>
   );

--- a/src/components/GradeInput.tsx
+++ b/src/components/GradeInput.tsx
@@ -1,0 +1,89 @@
+import { Check, ChevronDown } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { useState } from 'react';
+import { useDropdown } from '../hooks/useDropDown';
+import { Grade } from '../machines/studentMachine';
+
+const grades = [1, 2, 3, 4, 5] as const;
+
+interface GradeInputProps {
+  onNext: (grade: Grade) => void;
+}
+
+const GradeInput = ({ onNext }: GradeInputProps) => {
+  const [grade, setGrade] = useState<Grade>();
+  const [showLabel, setShowLabel] = useState(false);
+  const [showDropdown, setShowDropdown, dropDownRef] = useDropdown();
+
+  const handleGradeSelect = (grade: Grade) => {
+    setGrade(grade);
+    setShowDropdown(false);
+
+    // 라벨 보이기
+    setShowLabel(true);
+    // 다음 단계로 넘어가기
+    onNext(grade);
+  };
+
+  return (
+    <motion.div
+      initial={{
+        opacity: 0,
+        y: -20,
+      }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{
+        duration: 0.3,
+        ease: 'easeOut',
+      }}
+    >
+      {showLabel && <label className="mb-1.5 block text-sm">학년</label>}
+      <div className="relative" ref={dropDownRef}>
+        <div
+          className="bg-basic-light focus-visible:ring-ring flex w-full items-center justify-between rounded-lg px-4 py-3 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
+          onClick={() => setShowDropdown(!showDropdown)}
+        >
+          <span className={`text-lg font-semibold ${grade ? 'text-primary' : 'text-placeholder'}`}>
+            {grade ?? '학년'}
+          </span>
+          <ChevronDown className="size-4" />
+        </div>
+        <AnimatePresence>
+          {showDropdown && (
+            <motion.ul
+              className="bg-basic-light absolute z-10 mt-2 w-full rounded-lg border border-gray-200 shadow-sm"
+              initial={{ opacity: 0, y: -10 }}
+              animate={{
+                opacity: 1,
+                y: 0,
+              }}
+              exit={{
+                opacity: 0,
+                y: -10,
+              }}
+              transition={{
+                duration: 0.2,
+              }}
+            >
+              {grades.map((gradeOption) => (
+                <li key={gradeOption}>
+                  <button
+                    className="text-list flex w-full items-center justify-between rounded-lg px-4 py-2 text-lg font-semibold hover:bg-gray-100"
+                    onClick={() => {
+                      handleGradeSelect(gradeOption);
+                    }}
+                  >
+                    {gradeOption}
+                    {grade === gradeOption && <Check className="size-4 text-green-500" />}
+                  </button>
+                </li>
+              ))}
+            </motion.ul>
+          )}
+        </AnimatePresence>
+      </div>
+    </motion.div>
+  );
+};
+
+export default GradeInput;

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,16 @@
+interface ProgressBarProps {
+  width: number; // 0 to 100
+}
+
+const ProgressBar = ({ width }: ProgressBarProps) => {
+  return (
+    <div className="h-1 w-full bg-black">
+      <div
+        className="bg-progress-bar h-full transition-all duration-500"
+        style={{ width: `${width}%` }}
+      />
+    </div>
+  );
+};
+
+export default ProgressBar;

--- a/src/hooks/useDropDown.ts
+++ b/src/hooks/useDropDown.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef, useState } from 'react';
+
+export const useDropdown = () => {
+  const [showDropdown, setShowDropdown] = useState(false);
+  const dropDownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropDownRef.current && !dropDownRef.current.contains(event.target as Node)) {
+        setShowDropdown(false);
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, []);
+
+  return [showDropdown, setShowDropdown, dropDownRef] as const;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,7 @@
   --color-list: #686868;
   --color-ring: hsl(240 5% 64.9%);
   --color-placeholder: #cfcfcf;
+  --color-hint: #b5b9c4;
 }
 
 @layer base {

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
   --color-basic-light: #f7f8f8;
   --color-list: #686868;
   --color-ring: hsl(240 5% 64.9%);
+  --color-placeholder: #cfcfcf;
 }
 
 @layer base {

--- a/src/index.css
+++ b/src/index.css
@@ -2,5 +2,19 @@
 
 @theme {
   --font-pretendard: 'Pretendard Variable', sans-serif;
+  --color-primary: #674fd0;
   --color-progress-bar: #6b5cff;
+  --color-basic-light: #f7f8f8;
+  --color-list: #686868;
+  --color-ring: hsl(240 5% 64.9%);
+}
+
+@layer base {
+  body {
+    color: #292929;
+  }
+
+  input::placeholder {
+    color: #cfcfcf;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2,4 +2,5 @@
 
 @theme {
   --font-pretendard: 'Pretendard Variable', sans-serif;
+  --color-progress-bar: #6b5cff;
 }

--- a/src/machines/studentMachine.ts
+++ b/src/machines/studentMachine.ts
@@ -1,0 +1,73 @@
+import { assign, setup } from 'xstate';
+
+interface Context {
+  department: string; // 학과
+  admissionYear: number; // 입학년도
+  grade: 1 | 2 | 3 | 4 | 5; // 학년
+  chapel: boolean; // 채플 수강 여부
+}
+
+type Event =
+  | { type: '학과입력완료'; payload: { department: string } }
+  | { type: '입학년도입력완료'; payload: { admissionYear: number } }
+  | { type: '학년입력완료'; payload: { grade: 1 | 2 | 3 | 4 | 5 } }
+  | { type: '채플수강여부입력완료'; payload: { chapel: boolean } };
+
+const studentMachine = setup({
+  types: {
+    context: {} as Context,
+    events: {} as Event,
+  },
+}).createMachine({
+  id: 'student',
+  initial: '학과입력',
+  context: {
+    department: '',
+    admissionYear: 0,
+    grade: 1,
+    chapel: false,
+  },
+  states: {
+    학과입력: {
+      on: {
+        학과입력완료: {
+          target: '입학년도입력',
+          actions: assign({
+            department: ({ event }) => event.payload.department,
+          }),
+        },
+      },
+    },
+    입학년도입력: {
+      on: {
+        입학년도입력완료: {
+          target: '학년입력',
+          actions: assign({
+            admissionYear: ({ event }) => event.payload.admissionYear,
+          }),
+        },
+      },
+    },
+    학년입력: {
+      on: {
+        학년입력완료: {
+          target: '채플수강여부입력',
+          actions: assign({
+            grade: ({ event }) => event.payload.grade,
+          }),
+        },
+      },
+    },
+    채플수강여부입력: {
+      on: {
+        채플수강여부입력완료: {
+          actions: assign({
+            chapel: ({ event }) => event.payload.chapel,
+          }),
+        },
+      },
+    },
+  },
+});
+
+export default studentMachine;

--- a/src/machines/studentMachine.ts
+++ b/src/machines/studentMachine.ts
@@ -1,9 +1,11 @@
 import { assign, setup } from 'xstate';
 
+export type Grade = 1 | 2 | 3 | 4 | 5;
+
 interface Context {
   department: string; // 학과
   admissionYear: number; // 입학년도
-  grade: 1 | 2 | 3 | 4 | 5; // 학년
+  grade: Grade; // 학년
   chapel: boolean; // 채플 수강 여부
 }
 

--- a/src/pages/CourseSelectionActivity.tsx
+++ b/src/pages/CourseSelectionActivity.tsx
@@ -1,25 +1,21 @@
 import { AppScreen } from '@stackflow/plugin-basic-ui';
 import { ActivityComponentType } from '@stackflow/react';
+import AppBar from '../components/AppBar';
 import { useFlow } from '../stackflow';
 
-interface CourseSelectionParams {
-  title: string;
-}
-
-const CourseSelectionActivity: ActivityComponentType<CourseSelectionParams> = ({
-  params: { title },
-}) => {
-  const { pop } = useFlow();
+const CourseSelectionActivity: ActivityComponentType = () => {
+  const { push } = useFlow();
 
   const handleClickButton = () => {
-    pop();
+    push('OnboardingActivity', {});
   };
 
   return (
     <AppScreen>
-      <div className="min-h-screen px-2 py-8">
+      <div className="min-h-screen py-12">
+        <AppBar progress={100} />
         <div className="flex flex-col items-center">
-          <h1>{title}</h1>
+          <div>CourseSelection Page</div>
           <button onClick={handleClickButton}>Go to Onboarding page</button>
         </div>
       </div>

--- a/src/pages/OnboardingActivity.tsx
+++ b/src/pages/OnboardingActivity.tsx
@@ -4,6 +4,7 @@ import { ActivityComponentType } from '@stackflow/react';
 import { useMachine } from '@xstate/react';
 import AdmissionYearInput from '../components/AdmissionYearInput';
 import AppBar from '../components/AppBar';
+import ChapelInput from '../components/ChapelInput';
 import DepartmentInput from '../components/DepartmentInput';
 import GradeInput from '../components/GradeInput';
 import { default as studentMachine } from '../machines/studentMachine';
@@ -19,6 +20,8 @@ const OnboardingActivity: ActivityComponentType = () => {
           <h2 className="text-[28px] font-semibold">사용자님에 대해 알려주세요!</h2>
           <span className="mt-2 font-light">시간표를 만들기 위한 최소한의 정보가 필요해요.</span>
           <div className="mt-15 flex w-full flex-col gap-6 px-12">
+            {state.matches('채플수강여부입력') && <ChapelInput />}
+
             {(state.matches('학년입력') || state.matches('채플수강여부입력')) && (
               <GradeInput
                 onNext={(grade) =>

--- a/src/pages/OnboardingActivity.tsx
+++ b/src/pages/OnboardingActivity.tsx
@@ -1,20 +1,18 @@
 import { AppScreen } from '@stackflow/plugin-basic-ui';
 import { ActivityComponentType } from '@stackflow/react';
-import { useFlow } from '../stackflow';
+
+import AppBar from '../components/AppBar';
 
 const OnboardingActivity: ActivityComponentType = () => {
-  const { push } = useFlow();
-
-  const handleClickButton = () => {
-    push('CourseSelectionActivity', {
-      title: 'Hello from Onboarding',
-    });
-  };
-
   return (
-    <AppScreen appBar={{ title: 'Onboarding Activity' }}>
-      <div className="flex">Onboarding Activity</div>
-      <button onClick={handleClickButton}>Go to CourseSelection page</button>
+    <AppScreen>
+      <div className="min-h-screen py-12">
+        <AppBar progress={100} />
+        <div className="mt-10 flex flex-col items-center">
+          <h2 className="text-[28px] font-semibold">사용자님에 대해 알려주세요!</h2>
+          <span className="mt-2 font-light">시간표를 만들기 위한 최소한의 정보가 필요해요.</span>
+        </div>
+      </div>
     </AppScreen>
   );
 };

--- a/src/pages/OnboardingActivity.tsx
+++ b/src/pages/OnboardingActivity.tsx
@@ -2,6 +2,7 @@ import { AppScreen } from '@stackflow/plugin-basic-ui';
 import { ActivityComponentType } from '@stackflow/react';
 
 import { useMachine } from '@xstate/react';
+import { useEffect, useState } from 'react';
 import AdmissionYearInput from '../components/AdmissionYearInput';
 import AppBar from '../components/AppBar';
 import ChapelInput from '../components/ChapelInput';
@@ -11,16 +12,37 @@ import { default as studentMachine } from '../machines/studentMachine';
 
 const OnboardingActivity: ActivityComponentType = () => {
   const [state, send] = useMachine(studentMachine);
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const stateProgressMap = {
+      학과입력: 25,
+      입학년도입력: 50,
+      학년입력: 75,
+      채플수강여부입력: 100,
+    };
+
+    setProgress(stateProgressMap[state.value]);
+  }, [state.value]);
 
   return (
     <AppScreen>
       <div className="min-h-screen py-12">
-        <AppBar progress={100} />
+        <AppBar progress={progress} />
         <div className="mt-15 flex flex-col items-center">
           <h2 className="text-[28px] font-semibold">사용자님에 대해 알려주세요!</h2>
           <span className="mt-1 font-light">시간표를 만들기 위한 최소한의 정보가 필요해요.</span>
           <div className="mt-12 flex w-full flex-col gap-6 px-12">
-            {state.matches('채플수강여부입력') && <ChapelInput />}
+            {state.matches('채플수강여부입력') && (
+              <ChapelInput
+                onNext={(chapel) =>
+                  send({
+                    type: '채플수강여부입력완료',
+                    payload: { chapel },
+                  })
+                }
+              />
+            )}
 
             {(state.matches('학년입력') || state.matches('채플수강여부입력')) && (
               <GradeInput
@@ -50,6 +72,7 @@ const OnboardingActivity: ActivityComponentType = () => {
               onNext={(department) => send({ type: '학과입력완료', payload: { department } })}
             />
           </div>
+
           {state.matches('채플수강여부입력') && (
             <button
               type="button"

--- a/src/pages/OnboardingActivity.tsx
+++ b/src/pages/OnboardingActivity.tsx
@@ -1,16 +1,28 @@
 import { AppScreen } from '@stackflow/plugin-basic-ui';
 import { ActivityComponentType } from '@stackflow/react';
 
+import { useMachine } from '@xstate/react';
 import AppBar from '../components/AppBar';
+import DepartmentInput from '../components/DepartmentInput';
+import studentMachine from '../machines/studentMachine';
 
 const OnboardingActivity: ActivityComponentType = () => {
+  const [state, send] = useMachine(studentMachine);
+
+  console.log(state);
+
   return (
     <AppScreen>
       <div className="min-h-screen py-12">
         <AppBar progress={100} />
-        <div className="mt-10 flex flex-col items-center">
+        <div className="mt-15 flex flex-col items-center">
           <h2 className="text-[28px] font-semibold">사용자님에 대해 알려주세요!</h2>
           <span className="mt-2 font-light">시간표를 만들기 위한 최소한의 정보가 필요해요.</span>
+          <div className="mt-15 w-full px-12">
+            <DepartmentInput
+              onNext={(department) => send({ type: '학과입력완료', payload: { department } })}
+            />
+          </div>
         </div>
       </div>
     </AppScreen>

--- a/src/pages/OnboardingActivity.tsx
+++ b/src/pages/OnboardingActivity.tsx
@@ -2,14 +2,13 @@ import { AppScreen } from '@stackflow/plugin-basic-ui';
 import { ActivityComponentType } from '@stackflow/react';
 
 import { useMachine } from '@xstate/react';
+import AdmissionYearInput from '../components/AdmissionYearInput';
 import AppBar from '../components/AppBar';
 import DepartmentInput from '../components/DepartmentInput';
-import studentMachine from '../machines/studentMachine';
+import { default as studentMachine } from '../machines/studentMachine';
 
 const OnboardingActivity: ActivityComponentType = () => {
   const [state, send] = useMachine(studentMachine);
-
-  console.log(state);
 
   return (
     <AppScreen>
@@ -18,7 +17,20 @@ const OnboardingActivity: ActivityComponentType = () => {
         <div className="mt-15 flex flex-col items-center">
           <h2 className="text-[28px] font-semibold">사용자님에 대해 알려주세요!</h2>
           <span className="mt-2 font-light">시간표를 만들기 위한 최소한의 정보가 필요해요.</span>
-          <div className="mt-15 w-full px-12">
+          <div className="mt-15 flex w-full flex-col gap-6 px-12">
+            {(state.matches('입학년도입력') ||
+              state.matches('학년입력') ||
+              state.matches('채플수강여부입력')) && (
+              <AdmissionYearInput
+                onNext={(admissionYear) =>
+                  send({
+                    type: '입학년도입력완료',
+                    payload: { admissionYear },
+                  })
+                }
+              />
+            )}
+
             <DepartmentInput
               onNext={(department) => send({ type: '학과입력완료', payload: { department } })}
             />

--- a/src/pages/OnboardingActivity.tsx
+++ b/src/pages/OnboardingActivity.tsx
@@ -18,8 +18,8 @@ const OnboardingActivity: ActivityComponentType = () => {
         <AppBar progress={100} />
         <div className="mt-15 flex flex-col items-center">
           <h2 className="text-[28px] font-semibold">사용자님에 대해 알려주세요!</h2>
-          <span className="mt-2 font-light">시간표를 만들기 위한 최소한의 정보가 필요해요.</span>
-          <div className="mt-15 flex w-full flex-col gap-6 px-12">
+          <span className="mt-1 font-light">시간표를 만들기 위한 최소한의 정보가 필요해요.</span>
+          <div className="mt-12 flex w-full flex-col gap-6 px-12">
             {state.matches('채플수강여부입력') && <ChapelInput />}
 
             {(state.matches('학년입력') || state.matches('채플수강여부입력')) && (
@@ -50,6 +50,14 @@ const OnboardingActivity: ActivityComponentType = () => {
               onNext={(department) => send({ type: '학과입력완료', payload: { department } })}
             />
           </div>
+          {state.matches('채플수강여부입력') && (
+            <button
+              type="button"
+              className="bg-progress-bar mt-14 w-50 rounded-2xl py-3.5 font-semibold text-white"
+            >
+              다 입력했어요
+            </button>
+          )}
         </div>
       </div>
     </AppScreen>

--- a/src/pages/OnboardingActivity.tsx
+++ b/src/pages/OnboardingActivity.tsx
@@ -5,6 +5,7 @@ import { useMachine } from '@xstate/react';
 import AdmissionYearInput from '../components/AdmissionYearInput';
 import AppBar from '../components/AppBar';
 import DepartmentInput from '../components/DepartmentInput';
+import GradeInput from '../components/GradeInput';
 import { default as studentMachine } from '../machines/studentMachine';
 
 const OnboardingActivity: ActivityComponentType = () => {
@@ -18,6 +19,17 @@ const OnboardingActivity: ActivityComponentType = () => {
           <h2 className="text-[28px] font-semibold">사용자님에 대해 알려주세요!</h2>
           <span className="mt-2 font-light">시간표를 만들기 위한 최소한의 정보가 필요해요.</span>
           <div className="mt-15 flex w-full flex-col gap-6 px-12">
+            {(state.matches('학년입력') || state.matches('채플수강여부입력')) && (
+              <GradeInput
+                onNext={(grade) =>
+                  send({
+                    type: '학년입력완료',
+                    payload: { grade },
+                  })
+                }
+              />
+            )}
+
             {(state.matches('입학년도입력') ||
               state.matches('학년입력') ||
               state.matches('채플수강여부입력')) && (

--- a/src/stackflow.ts
+++ b/src/stackflow.ts
@@ -16,5 +16,5 @@ export const { Stack, useFlow } = stackflow({
     OnboardingActivity,
     CourseSelectionActivity,
   },
-  initialActivity: () => 'OnboardingActivity',
+  initialActivity: () => 'CourseSelectionActivity',
 });

--- a/src/stackflow.ts
+++ b/src/stackflow.ts
@@ -16,5 +16,5 @@ export const { Stack, useFlow } = stackflow({
     OnboardingActivity,
     CourseSelectionActivity,
   },
-  initialActivity: () => 'CourseSelectionActivity',
+  initialActivity: () => 'OnboardingActivity',
 });


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolved #1 

## 📝작업 내용

- 온보딩 페이지를 구현했습니다.

https://github.com/user-attachments/assets/cc333c7b-81cb-4be6-b3ba-f4cc7e56edab

## 💬리뷰 요구사항
- 각 입력폼이 입력 여부에 따라 순서대로 보여지니 FSM으로 상태를 관리할 수 있는 도구인 [XState](https://stately.ai/docs/xstate)를 사용해 보았는데 삽질하느라 시간만 날린 것 같네요 쩝
- Select나 Dropdown에 [Radix-ui](https://www.radix-ui.com/primitives)를 사용하고 싶었는데 [stackflow](https://stackflow.so/)랑 같이 사용하니까 빈 화면만 보이는 버그가 있어 포기하고 직접 구현했습니다.
- stackflow 사용법이 살짝 복잡해서 https://youtu.be/qLfqYhSgUqM?si=HLT2u5X3ETLmR3zK 영상 추천드립니다👍


