### PR TITLE
feat: 사용자가 전공선택 학점을 입력할 수 있도록 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "motion": "^12.0.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "tailwind-merge": "^3.0.1",
     "tailwindcss": "^4.0.0",
     "xstate": "^5.19.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      tailwind-merge:
+        specifier: ^3.0.1
+        version: 3.0.1
       tailwindcss:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1843,6 +1846,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  tailwind-merge@3.0.1:
+    resolution: {integrity: sha512-AvzE8FmSoXC7nC+oU5GlQJbip2UO7tmOhOfQyOmPhrStOGXHU08j8mZEHZ4BmCqY5dWTCo4ClWkNyRNx1wpT0g==}
+
   tailwindcss@4.0.0:
     resolution: {integrity: sha512-ULRPI3A+e39T7pSaf1xoi58AqqJxVCLg8F/uM5A3FadUbnyDTgltVnXJvdkTjwCOGA6NazqHVcwPJC5h2vRYVQ==}
 
@@ -3546,6 +3552,8 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  tailwind-merge@3.0.1: {}
 
   tailwindcss@4.0.0: {}
 

--- a/src/components/GradeInput.tsx
+++ b/src/components/GradeInput.tsx
@@ -1,9 +1,10 @@
 import * as Popover from '@radix-ui/react-popover';
-import { Check, ChevronDown, Info } from 'lucide-react';
+import { Check, ChevronDown } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 import { grades } from '../data/grades';
 import { Grade } from '../machines/studentMachine';
+import Hint from './Hint';
 
 interface GradeInputProps {
   initialValue: Grade | undefined;
@@ -88,10 +89,10 @@ const GradeInput = ({ onNext, initialValue }: GradeInputProps) => {
         </AnimatePresence>
       </Popover.Root>
 
-      <div className="text-hint mt-1.5 flex items-center gap-2">
-        <Info className="size-3" />
-        <span className="text-xs">이번 학기에 이수 예정인 학년을 선택해주세요.</span>
-      </div>
+      <Hint className="mt-2">
+        <Hint.Icon />
+        <Hint.Text>이번 학기에 이수 예정인 학년을 선택해주세요.</Hint.Text>
+      </Hint>
     </motion.div>
   );
 };

--- a/src/components/Hint.tsx
+++ b/src/components/Hint.tsx
@@ -1,0 +1,40 @@
+import { Info } from 'lucide-react';
+import { ElementType, HTMLAttributes, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+interface HintProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+interface HintTextProps extends HTMLAttributes<HTMLSpanElement> {
+  children: ReactNode;
+}
+
+interface HintIconProps extends HTMLAttributes<SVGSVGElement> {
+  as?: ElementType;
+}
+
+const Hint = ({ children, className, ...props }: HintProps) => {
+  return (
+    <div className={`text-hint flex items-center gap-2 ${twMerge(className)}`} {...props}>
+      {children}
+    </div>
+  );
+};
+
+const HintText = ({ children, className, ...props }: HintTextProps) => {
+  return (
+    <span className={`text-xs ${twMerge(className)}`} {...props}>
+      {children}
+    </span>
+  );
+};
+
+const HintIcon = ({ as: Icon = Info, className, ...props }: HintIconProps) => {
+  return <Icon className={`size-3 ${twMerge(className)}`} {...props} />;
+};
+
+Hint.Text = HintText;
+Hint.Icon = HintIcon;
+
+export default Hint;

--- a/src/pages/DesiredCreditActivity.tsx
+++ b/src/pages/DesiredCreditActivity.tsx
@@ -76,9 +76,9 @@ const DesiredCreditActivity: ActivityComponentType<DesiredCreditParams> = ({ par
 
   return (
     <AppScreen>
-      <div className="min-h-screen py-12">
+      <div className="flex min-h-screen flex-col py-12">
         <AppBar progress={100} />
-        <div className="mt-15 flex flex-col items-center">
+        <div className="mt-15 flex flex-1 flex-col items-center">
           <h2 className="text-center text-[28px] font-semibold">
             사용자님의 이번학기 <br />
             희망 학점은 <RollingNumber number={desiredCredit} className="text-primary" />
@@ -236,7 +236,7 @@ const DesiredCreditActivity: ActivityComponentType<DesiredCreditParams> = ({ par
           {(majorElective !== credit.majorElective || generalElective > 0) && (
             <motion.button
               type="button"
-              className="bg-primary mt-57 w-50 rounded-2xl py-3.5 font-semibold text-white"
+              className="bg-primary mt-auto mb-5 w-50 rounded-2xl py-3.5 font-semibold text-white"
               initial={{
                 opacity: 0,
                 y: 20,

--- a/src/pages/DesiredCreditActivity.tsx
+++ b/src/pages/DesiredCreditActivity.tsx
@@ -6,6 +6,7 @@ import { Check, ChevronDown } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 import AppBar from '../components/AppBar';
+import Hint from '../components/Hint';
 import RollingNumber from '../components/RollingNumber';
 
 type DesiredCreditParams = {
@@ -226,6 +227,11 @@ const DesiredCreditActivity: ActivityComponentType<DesiredCreditParams> = ({ par
               </Popover.Root>
             </div>
           </div>
+
+          <Hint className="mt-2 self-start px-12">
+            <Hint.Icon />
+            <Hint.Text>이수 가능한 최대 학점은 22학점이에요.</Hint.Text>
+          </Hint>
 
           {(majorElective !== credit.majorElective || generalElective > 0) && (
             <motion.button

--- a/src/pages/DesiredCreditActivity.tsx
+++ b/src/pages/DesiredCreditActivity.tsx
@@ -8,33 +8,69 @@ import { useState } from 'react';
 import AppBar from '../components/AppBar';
 import RollingNumber from '../components/RollingNumber';
 
-interface DesiredCreditParams {
+type DesiredCreditParams = {
   majorRequired: number;
   majorElective: number;
   generalRequired: number;
-}
-
-const Classification = {
-  majorRequired: '전공필수',
-  majorElective: '전공선택',
-  generalRequired: '교양필수',
-  generalElective: '교양선택',
 };
+
+const getAvailableCredits = (currentCredit: number, baseCredit: number = 0) => {
+  return Array.from({ length: MAX_CREDIT - currentCredit + 1 }, (_, i) => i + baseCredit);
+};
+
+type Classification = '전공필수' | '전공선택' | '교양필수' | '교양선택';
 
 const MAX_CREDIT = 22;
 
 const DesiredCreditActivity: ActivityComponentType<DesiredCreditParams> = ({ params: credit }) => {
-  const totalCredit = Object.values(credit).reduce((acc, credit) => acc + credit, 0); // 전공필수 + 전공선택 + 교양필수
-  const availableCredits = Array.from({ length: MAX_CREDIT - totalCredit + 1 }, (_, i) => i); // 수강 가능한 교양선택 학점
+  const previousCredit = Object.values(credit).reduce((acc, credit) => acc + credit, 0); // 과목 선택 페이지에서 선택한 전필 + 전선 + 교필 학점
+  const [desiredCredit, setDesiredCredit] = useState(previousCredit); // 희망 학점
 
-  const [desiredCredit, setDesiredCredit] = useState(totalCredit);
-  const [generalElective, setGeneralElective] = useState(0);
-  const [showDropdown, setShowDropdown] = useState(false);
+  const [availableMajorElective, setAvailableMajorElective] = useState(() =>
+    getAvailableCredits(previousCredit, credit.majorElective),
+  ); // 수강 가능한 전공선택 학점
+  const [availableGeneralElective, setAvailableGeneralElective] = useState(() =>
+    getAvailableCredits(previousCredit),
+  ); // 수강 가능한 교양선택 학점
 
-  const handleCreditSelect = (credit: number) => {
-    setGeneralElective(credit);
-    setDesiredCredit(totalCredit + credit);
-    setShowDropdown(false);
+  const [majorElective, setMajorElective] = useState(credit.majorElective); // 전공선택 학점
+  const [generalElective, setGeneralElective] = useState(0); // 교양선택 학점
+
+  const [showMajorElectiveDropdown, setShowMajorElectiveDropdown] = useState(false);
+  const [showGeneralElectiveDropdown, setShowGeneralElectiveDropdown] = useState(false);
+
+  const handleCreditSelect = ({
+    type,
+    selectedCredit,
+  }: {
+    type: Classification;
+    selectedCredit: number;
+  }) => {
+    if (type === '전공선택') {
+      const majorElectiveDiff = selectedCredit - majorElective;
+
+      setMajorElective(selectedCredit);
+      setDesiredCredit((prev) => prev + majorElectiveDiff);
+      setAvailableGeneralElective(
+        getAvailableCredits(desiredCredit + majorElectiveDiff - generalElective),
+      );
+
+      setShowMajorElectiveDropdown(false);
+    } else if (type === '교양선택') {
+      const generalElectiveDiff = selectedCredit - generalElective;
+      const majorElectiveDiff = majorElective - credit.majorElective;
+
+      setGeneralElective(selectedCredit);
+      setDesiredCredit((prev) => prev + generalElectiveDiff);
+      setAvailableMajorElective(
+        getAvailableCredits(
+          desiredCredit + generalElectiveDiff - majorElectiveDiff,
+          credit.majorElective,
+        ),
+      );
+
+      setShowGeneralElectiveDropdown(false);
+    }
   };
 
   return (
@@ -47,37 +83,36 @@ const DesiredCreditActivity: ActivityComponentType<DesiredCreditParams> = ({ par
             희망 학점은 <RollingNumber number={desiredCredit} className="text-primary" />
             학점이군요!
           </h2>
-          <span className="mt-1 font-light">희망 학점에 맞추어 교양선택과목을 추천해드릴게요.</span>
+          <span className="mt-1 font-light">희망 학점에 맞추어 선택과목을 추천해드릴게요.</span>
           <div className="mt-15 grid grid-cols-2 gap-x-2.5 gap-y-6 px-12">
-            {Object.entries(credit).map(([key, value]) => (
-              <div key={key}>
-                <label className="mb-1.5 block text-sm">
-                  {Classification[key as keyof typeof Classification]} 학점
-                </label>
-                <input
-                  type="number"
-                  disabled
-                  value={value}
-                  className="bg-basic-light text-primary w-full rounded-xl px-4 py-3 text-lg font-semibold"
-                />
-              </div>
-            ))}
             <div>
-              <label className="mb-1.5 block text-sm">교양선택 학점</label>
+              <label className="mb-1.5 block text-sm">전공필수 학점</label>
+              <input
+                type="number"
+                disabled
+                value={credit.majorRequired}
+                className="bg-basic-light text-primary w-full rounded-xl px-4 py-3 text-lg font-semibold"
+              />
+            </div>
 
-              <Popover.Root open={showDropdown} onOpenChange={setShowDropdown}>
+            <div>
+              <label className="mb-1.5 block text-sm">전공선택 학점</label>
+              <Popover.Root
+                open={showMajorElectiveDropdown}
+                onOpenChange={setShowMajorElectiveDropdown}
+              >
                 <Popover.Trigger asChild>
                   <button
                     type="button"
-                    className={`bg-basic-light focus-visible:outline-ring flex w-full items-center justify-between rounded-xl px-4 py-3 text-lg font-semibold ${generalElective === 0 ? 'text-placeholder' : 'text-primary'}`}
+                    className={`bg-basic-light focus-visible:outline-ring flex w-full items-center justify-between rounded-xl px-4 py-3 text-lg font-semibold ${majorElective === credit.majorElective ? 'text-placeholder' : 'text-primary'}`}
                   >
-                    {generalElective}
+                    {majorElective}
                     <ChevronDown className="text-text size-4" />
                   </button>
                 </Popover.Trigger>
 
                 <AnimatePresence>
-                  {showDropdown && (
+                  {showMajorElectiveDropdown && (
                     <Popover.Content asChild sideOffset={5} forceMount>
                       <motion.ul
                         className="bg-basic-light z-10 max-h-44 w-[var(--radix-popover-trigger-width)] overflow-y-auto rounded-xl border border-gray-200 shadow-sm"
@@ -94,12 +129,88 @@ const DesiredCreditActivity: ActivityComponentType<DesiredCreditParams> = ({ par
                           duration: 0.2,
                         }}
                       >
-                        {availableCredits.map((availableCredit) => (
+                        {availableMajorElective.map((availableCredit) => (
                           <li key={availableCredit}>
                             <button
                               type="button"
                               className="text-list focus-visible:outline-ring flex w-full items-center justify-between rounded-xl px-4 py-2 text-lg font-semibold hover:bg-gray-100 focus-visible:-outline-offset-1"
-                              onClick={() => handleCreditSelect(availableCredit)}
+                              onClick={() =>
+                                handleCreditSelect({
+                                  type: '전공선택',
+                                  selectedCredit: availableCredit,
+                                })
+                              }
+                            >
+                              {availableCredit}
+                              {availableCredit === majorElective && (
+                                <Check className="size-4 text-green-500" />
+                              )}
+                            </button>
+                          </li>
+                        ))}
+                      </motion.ul>
+                    </Popover.Content>
+                  )}
+                </AnimatePresence>
+              </Popover.Root>
+            </div>
+
+            <div>
+              <label className="mb-1.5 block text-sm">교양필수 학점</label>
+              <input
+                type="number"
+                disabled
+                value={credit.generalRequired}
+                className="bg-basic-light text-primary w-full rounded-xl px-4 py-3 text-lg font-semibold"
+              />
+            </div>
+
+            <div>
+              <label className="mb-1.5 block text-sm">교양선택 학점</label>
+
+              <Popover.Root
+                open={showGeneralElectiveDropdown}
+                onOpenChange={setShowGeneralElectiveDropdown}
+              >
+                <Popover.Trigger asChild>
+                  <button
+                    type="button"
+                    className={`bg-basic-light focus-visible:outline-ring flex w-full items-center justify-between rounded-xl px-4 py-3 text-lg font-semibold ${generalElective === 0 ? 'text-placeholder' : 'text-primary'}`}
+                  >
+                    {generalElective}
+                    <ChevronDown className="text-text size-4" />
+                  </button>
+                </Popover.Trigger>
+
+                <AnimatePresence>
+                  {showGeneralElectiveDropdown && (
+                    <Popover.Content asChild sideOffset={5} forceMount>
+                      <motion.ul
+                        className="bg-basic-light z-10 max-h-44 w-[var(--radix-popover-trigger-width)] overflow-y-auto rounded-xl border border-gray-200 shadow-sm"
+                        initial={{ opacity: 0, y: -10 }}
+                        animate={{
+                          opacity: 1,
+                          y: 0,
+                        }}
+                        exit={{
+                          opacity: 0,
+                          y: -10,
+                        }}
+                        transition={{
+                          duration: 0.2,
+                        }}
+                      >
+                        {availableGeneralElective.map((availableCredit) => (
+                          <li key={availableCredit}>
+                            <button
+                              type="button"
+                              className="text-list focus-visible:outline-ring flex w-full items-center justify-between rounded-xl px-4 py-2 text-lg font-semibold hover:bg-gray-100 focus-visible:-outline-offset-1"
+                              onClick={() =>
+                                handleCreditSelect({
+                                  type: '교양선택',
+                                  selectedCredit: availableCredit,
+                                })
+                              }
                             >
                               {availableCredit}
                               {availableCredit === generalElective && (
@@ -116,7 +227,7 @@ const DesiredCreditActivity: ActivityComponentType<DesiredCreditParams> = ({ par
             </div>
           </div>
 
-          {generalElective > 0 && (
+          {(majorElective !== credit.majorElective || generalElective > 0) && (
             <motion.button
               type="button"
               className="bg-primary mt-57 w-50 rounded-2xl py-3.5 font-semibold text-white"

--- a/src/pages/OnboardingActivity.tsx
+++ b/src/pages/OnboardingActivity.tsx
@@ -3,7 +3,7 @@ import { ActivityComponentType } from '@stackflow/react';
 
 import { useMachine } from '@xstate/react';
 import { motion } from 'motion/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import AdmissionYearInput from '../components/AdmissionYearInput';
 import AppBar from '../components/AppBar';
 import ChapelInput from '../components/ChapelInput';
@@ -25,6 +25,8 @@ const OnboardingActivity: ActivityComponentType = () => {
   const [progress, setProgress] = useState(0);
   const { push } = useFlow();
 
+  const submitButtonRef = useRef<HTMLButtonElement>(null);
+
   useEffect(() => {
     const stateProgressMap = {
       학과입력: 25,
@@ -35,6 +37,12 @@ const OnboardingActivity: ActivityComponentType = () => {
 
     setProgress(stateProgressMap[state.value]);
   }, [state.value]);
+
+  useEffect(() => {
+    if (state.matches('채플수강여부입력')) {
+      submitButtonRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [state]);
 
   const handleClickButton = () => {
     // actorRef.getPersistedSnapshot()을 통해 현재 state를 가져옴
@@ -51,12 +59,12 @@ const OnboardingActivity: ActivityComponentType = () => {
 
   return (
     <AppScreen>
-      <div className="min-h-screen py-12">
+      <div className="flex min-h-screen flex-col py-12">
         <AppBar progress={progress} />
-        <div className="mt-15 flex flex-col items-center">
+        <div className="mt-15 flex flex-1 flex-col items-center">
           <h2 className="text-[28px] font-semibold">사용자님에 대해 알려주세요!</h2>
           <span className="mt-1 font-light">시간표를 만들기 위한 최소한의 정보가 필요해요.</span>
-          <div className="mt-12 flex w-full flex-col gap-6 px-12">
+          <div className="my-12 flex w-full flex-col gap-6 px-12">
             {state.matches('채플수강여부입력') && (
               <ChapelInput
                 initialValue={restoredState?.context?.chapel}
@@ -103,12 +111,13 @@ const OnboardingActivity: ActivityComponentType = () => {
 
           {state.matches('채플수강여부입력') && (
             <motion.button
+              ref={submitButtonRef}
               type="button"
               onClick={handleClickButton}
-              className="bg-primary mt-14 w-50 rounded-2xl py-3.5 font-semibold text-white"
+              className="bg-primary mt-auto mb-5 w-50 rounded-2xl py-3.5 font-semibold text-white"
               initial={{
                 opacity: 0,
-                y: -20,
+                y: 20,
               }}
               animate={{ opacity: 1, y: 0 }}
               transition={{


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolve #11 

## 📝작업 내용
- 초기 기획대로 희망 학점 선택 페이지에서 사용자가 전공선택 학점을 입력할 수 있도록 수정했습니다.
- 전공필수 + 전공선택 + 교양필수 + 교양선택 학점의 총합이 22학점을 넘지 않도록 전공선택, 교양선택 학점 선택 옵션을 제한했습니다.
- 희망 학점 선택 페이지와 온보딩 페이지의 학년 입력 필드에 사용되는 `Hint` 컴포넌트를 구현했습니다.


https://github.com/user-attachments/assets/a5890576-4971-4ea9-9ba6-599ba846c6bf

