### PR TITLE
API 클라이언트, React Query 커스텀 훅 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/vite": "^4.0.0",
     "@tanstack/react-query": "^5.64.2",
     "@xstate/react": "^5.0.2",
+    "ky": "^1.7.4",
     "lucide-react": "^0.473.0",
     "motion": "^12.0.6",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-dom": "^18.3.1",
     "tailwind-merge": "^3.0.1",
     "tailwindcss": "^4.0.0",
-    "xstate": "^5.19.2"
+    "xstate": "^5.19.2",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@xstate/react':
         specifier: ^5.0.2
         version: 5.0.2(@types/react@18.3.18)(react@18.3.1)(xstate@5.19.2)
+      ky:
+        specifier: ^1.7.4
+        version: 1.7.4
       lucide-react:
         specifier: ^0.473.0
         version: 0.473.0(react@18.3.1)
@@ -1413,6 +1416,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  ky@1.7.4:
+    resolution: {integrity: sha512-zYEr/gh7uLW2l4su11bmQ2M9xLgQLjyvx58UyNM/6nuqyWFHPX5ktMjvpev3F8QWdjSsHUpnWew4PBCswBNuMQ==}
+    engines: {node: '>=18'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3205,6 +3212,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  ky@1.7.4: {}
 
   levn@0.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       xstate:
         specifier: ^5.19.2
         version: 5.19.2
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.17.0
@@ -2007,6 +2010,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -3661,3 +3667,5 @@ snapshots:
   yaml@2.6.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.24.1: {}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,7 @@
+import ky from 'ky';
+
+const api = ky.create({
+  prefixUrl: import.meta.env.VITE_API_URL,
+});
+
+export default api;

--- a/src/components/GradeInput.tsx
+++ b/src/components/GradeInput.tsx
@@ -3,7 +3,7 @@ import { Check, ChevronDown } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState } from 'react';
 import { grades } from '../data/grades';
-import { Grade } from '../machines/studentMachine';
+import { Grade } from '../schemas/studentSchema';
 import Hint from './Hint';
 
 interface GradeInputProps {

--- a/src/hooks/useGetGeneralRequired.ts
+++ b/src/hooks/useGetGeneralRequired.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../api/client';
+import { courseResponseSchema } from '../schemas/courseSchema';
+import { StudentWithoutChapel } from '../schemas/studentSchema';
+
+export const useGetGeneralElective = ({ schoolId, department, grade }: StudentWithoutChapel) => {
+  return useQuery({
+    queryKey: ['generalElective', { schoolId, department, grade }],
+    queryFn: async () => {
+      const response = await api
+        .get('courses/general/elective', {
+          searchParams: { schoolId, department, grade },
+        })
+        .json();
+
+      return courseResponseSchema.parse(response);
+    },
+  });
+};

--- a/src/hooks/useGetMajorRequired.ts
+++ b/src/hooks/useGetMajorRequired.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../api/client';
+import { courseResponseSchema } from '../schemas/courseSchema';
+import { StudentWithoutChapel } from '../schemas/studentSchema';
+
+export const useGetMajorRequired = ({ schoolId, department, grade }: StudentWithoutChapel) => {
+  return useQuery({
+    queryKey: ['majorRequired', { schoolId, department, grade }],
+    queryFn: async () => {
+      const response = await api
+        .get('courses/major/required', {
+          searchParams: { schoolId, department, grade },
+        })
+        .json();
+
+      return courseResponseSchema.parse(response);
+    },
+  });
+};

--- a/src/hooks/useGetMajotElective.ts
+++ b/src/hooks/useGetMajotElective.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../api/client';
+import { courseResponseSchema } from '../schemas/courseSchema';
+import { StudentWithoutChapel } from '../schemas/studentSchema';
+
+export const useGetMajorElective = ({ schoolId, department, grade }: StudentWithoutChapel) => {
+  return useQuery({
+    queryKey: ['majorElective', { schoolId, department, grade }],
+    queryFn: async () => {
+      const response = await api
+        .get('courses/major/elective', {
+          searchParams: { schoolId, department, grade },
+        })
+        .json();
+
+      return courseResponseSchema.parse(response);
+    },
+  });
+};

--- a/src/hooks/useGetTimetable.ts
+++ b/src/hooks/useGetTimetable.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../api/client';
+import { timetableResponseSchema } from '../schemas/timeTableSchema';
+
+export const useGetTimetable = (timetableId: number) => {
+  return useQuery({
+    queryKey: ['timetable', timetableId],
+    queryFn: async () => {
+      const response = await api.get(`timetables/${timetableId}`).json();
+
+      return timetableResponseSchema.parse(response);
+    },
+  });
+};

--- a/src/hooks/usePostTimetable.ts
+++ b/src/hooks/usePostTimetable.ts
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query';
+import api from '../api/client';
+
+import { StudentTimetable } from '../schemas/studentSchema';
+import { timetableArrayResponseSchema } from '../schemas/timeTableSchema';
+
+export const usePostTimetable = (student: StudentTimetable) => {
+  return useMutation({
+    mutationKey: ['timetable', student],
+    mutationFn: async () => {
+      const response = await api
+        .post('timetables', {
+          json: student,
+        })
+        .json();
+
+      return timetableArrayResponseSchema.parse(response);
+    },
+  });
+};

--- a/src/machines/studentMachine.ts
+++ b/src/machines/studentMachine.ts
@@ -1,6 +1,5 @@
 import { assign, setup } from 'xstate';
-
-export type Grade = 1 | 2 | 3 | 4 | 5;
+import { Grade } from '../schemas/studentSchema';
 
 type Context = {
   department: string; // 학과
@@ -12,7 +11,7 @@ type Context = {
 type Event =
   | { type: '학과입력완료'; payload: { department: string } }
   | { type: '입학년도입력완료'; payload: { admissionYear: number } }
-  | { type: '학년입력완료'; payload: { grade: 1 | 2 | 3 | 4 | 5 } }
+  | { type: '학년입력완료'; payload: { grade: Grade } }
   | { type: '채플수강여부입력완료'; payload: { chapel: boolean } };
 
 const studentMachine = setup({

--- a/src/schemas/courseSchema.ts
+++ b/src/schemas/courseSchema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const courseTimeSchema = z.object({
+  week: z.string(),
+  start: z.string(),
+  end: z.string(),
+  classroom: z.string(),
+});
+
+export const courseSchema = z.object({
+  courseName: z.string(),
+  professorName: z.string(),
+  classification: z.string(),
+  credit: z.number(),
+  target: z.array(z.string()),
+  courseTime: z.array(courseTimeSchema),
+});
+
+export const courseResponseSchema = z.object({
+  timestamp: z.string().datetime(),
+  result: z.array(courseSchema),
+});

--- a/src/schemas/studentSchema.ts
+++ b/src/schemas/studentSchema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+const Grade = z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4), z.literal(5)]);
+
+export const studentSchema = z.object({
+  schoolId: z.number().int().min(15).max(25).describe('입학년도'),
+
+  department: z.string().describe('학과명'),
+
+  grade: Grade.describe('학년'),
+
+  isChapel: z.boolean().describe('채플 수강 여부'),
+});
+
+export const studentTimetableSchema = studentSchema.extend({
+  majorRequiredCourses: z.array(z.string()).describe('전공필수 과목 목록'),
+  majorElectiveCourses: z.array(z.string()).describe('전공선택 과목 목록'),
+  generalRequiredCourses: z.array(z.string()).describe('교양필수 과목 목록'),
+  majorElectiveCredit: z.number().int().nonnegative().describe('희망 전공선택 학점'),
+  generalElectiveCredit: z.number().int().nonnegative().describe('희망 교양선택 학점'),
+});
+
+export type Grade = z.infer<typeof Grade>;
+export type Student = z.infer<typeof studentSchema>;
+export type StudentWithoutChapel = Omit<Student, 'isChapel'>;
+export type StudentTimetable = z.infer<typeof studentTimetableSchema>;

--- a/src/schemas/timetableSchema.ts
+++ b/src/schemas/timetableSchema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { courseTimeSchema } from './courseSchema';
+
+const timetableCourseSchema = z.object({
+  courseName: z.string(),
+  professorName: z.string(),
+  classification: z.string(),
+  credit: z.number(),
+  courseTime: z.array(courseTimeSchema),
+});
+
+const timetableSchema = z.object({
+  timetableId: z.number(),
+  tag: z.string(),
+  courses: z.array(timetableCourseSchema),
+});
+
+export const timetableResponseSchema = z.object({
+  timestamp: z.string().datetime(),
+  result: timetableSchema,
+});
+
+export const timetableArrayResponseSchema = z.object({
+  timestamp: z.string().datetime(),
+  result: z.object({
+    timetables: z.array(timetableSchema),
+  }),
+});


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolve #13 

## 📝작업 내용

- API 서버와 통신할 HTTP 클라이언트를 추가하였습니다. ([ky](https://github.com/sindresorhus/ky))

- 런타임 타입 체크를 위한 [zod](https://zod.dev/?id=datetimes) 스키마를 추가하였습니다.

- 각 API를 React Query 훅으로 래핑하였습니다.