### PR TITLE
fix: 희망 학점 버튼 바로 띄우기

### DIFF
--- a/src/pages/DesiredCreditActivity.tsx
+++ b/src/pages/DesiredCreditActivity.tsx
@@ -261,24 +261,22 @@ const DesiredCreditActivity: ActivityComponentType<DesiredCreditParams> = ({ par
             <Hint.Text>이수 가능한 최대 학점은 22학점이에요.</Hint.Text>
           </Hint>
 
-          {(majorElective !== params.majorElective || generalElective > 0) && (
-            <motion.button
-              onClick={handleNextClick}
-              type="button"
-              className="bg-primary mt-auto w-50 rounded-2xl py-3.5 font-semibold text-white"
-              initial={{
-                opacity: 0,
-                y: 20,
-              }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{
-                duration: 0.3,
-                ease: 'easeOut',
-              }}
-            >
-              네 맞아요
-            </motion.button>
-          )}
+          <motion.button
+            onClick={handleNextClick}
+            type="button"
+            className="bg-primary mt-auto w-50 rounded-2xl py-3.5 font-semibold text-white"
+            initial={{
+              opacity: 0,
+              y: 20,
+            }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{
+              duration: 0.3,
+              ease: 'easeOut',
+            }}
+          >
+            네 맞아요
+          </motion.button>
         </div>
       </div>
     </AppScreen>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #34 

## 📝작업 내용

- 교양 선택 및 전공 선택 학점을 선택하지 않아도 버튼을 띄웁니다.

### 스크린샷 (선택)

<img width="1188" alt="image" src="https://github.com/user-attachments/assets/11ed89a3-20e6-419b-af24-8fa6944992a8" />
