### PR TITLE
fix: 시간표 선택 페이지 텍스트 가운데 정렬

### DIFF
--- a/src/pages/TimetableSelectionActivity.tsx
+++ b/src/pages/TimetableSelectionActivity.tsx
@@ -124,10 +124,8 @@ const TimetableSelectionActivity: ActivityComponentType = () => {
       <div className="flex min-h-dvh flex-col py-12">
         <AppBar progress={100} />
         <div className="mt-4 flex flex-1 flex-col items-center">
-          <h2 className="text-center text-[28px] font-semibold">
-            사용자님을 위한
-            <br />
-            시간표를 {timetableSelection[latestMutation.status].title}
+          <h2 className="text-center text-[28px] font-semibold whitespace-pre-wrap">
+            {`사용자님을 위한\n시간표를 ${timetableSelection[latestMutation.status].title}`}
           </h2>
           <div className="mt-4 w-full flex-1 overflow-hidden px-10" ref={emblaRef}>
             <div className="mt-4 flex flex-col" style={{ maxHeight: 'calc(100dvh - 250px)' }}>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #35 

## 📝작업 내용

- 가운데 정렬 잘 돼요.

### 스크린샷 (선택)

![응애응애응애](https://github.com/user-attachments/assets/583a1dbc-c982-4c2b-b2e4-13dd6836084a)
