### PR TITLE
fix: 과목 이름이 시간표 블록을 벗어나지 않도록 수정

### DIFF
--- a/src/components/Timetable.tsx
+++ b/src/components/Timetable.tsx
@@ -86,6 +86,25 @@ const getCoursePosition = (courseTime: CourseTime): { top: number; height: numbe
   return { top, height };
 };
 
+const getLineClamp = (courseTime: CourseTime): number => {
+  const [startHour, startMinute] = courseTime.start.split(':').map(Number);
+  const [endHour, endMinute] = courseTime.end.split(':').map(Number);
+
+  const start = startHour * 60 + startMinute;
+  const end = endHour * 60 + endMinute;
+
+  // 50분 이하 2줄 제한
+  if (end - start <= 50) {
+    return 2;
+  }
+  // 1시간 15분 이하 3줄 제한
+  else if (end - start <= 75) {
+    return 3;
+  } else {
+    return 4;
+  }
+};
+
 interface TimetableProps extends HTMLAttributes<HTMLDivElement> {
   timetable: TimetableType;
 }
@@ -214,6 +233,10 @@ const Timetable = ({ children, timetable, className, ...props }: TimetableProps)
                             borderColor: bgColor,
                             top: `${top}px`,
                             height: `${height}px`,
+                            display: '-webkit-box',
+                            WebkitBoxOrient: 'vertical',
+                            WebkitLineClamp: getLineClamp(courseTime),
+                            overflow: 'hidden',
                           }}
                         >
                           {course.courseName}

--- a/src/pages/TimetableSelectionActivity.tsx
+++ b/src/pages/TimetableSelectionActivity.tsx
@@ -88,7 +88,7 @@ const TimetableSelectionActivity: ActivityComponentType = () => {
             latestMutation.data.result.timetables.map((timetable, index) => (
               <div
                 key={timetable.timetableId}
-                className={`min-h-0 flex-shrink-0 transform-gpu pt-4`}
+                className={`min-h-0 flex-shrink-0 transform-gpu pt-4 first:pt-0`}
               >
                 <Timetable
                   timetable={timetable}
@@ -126,7 +126,7 @@ const TimetableSelectionActivity: ActivityComponentType = () => {
             {`사용자님을 위한\n시간표를 ${timetableSelection[latestMutation.status].title}`}
           </h2>
           <div className="mt-4 w-full flex-1 overflow-hidden px-10" ref={emblaRef}>
-            <div className="mt-4 flex flex-col" style={{ maxHeight: 'calc(100dvh - 250px)' }}>
+            <div className="flex flex-col" style={{ maxHeight: 'calc(100dvh - 250px)' }}>
               {timetableSelection[latestMutation.status].element}
             </div>
           </div>


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve #33 

## 📝작업 내용
- 과목 이름이 시간표 블록을 벗어나서 표시되지 않도록 시간표 높이에 따라 동적으로 [line-clamp](https://developer.mozilla.org/ko/docs/Web/CSS/line-clamp) 값을 결정하도록 수정하였습니다.

<img width="309" alt="image" src="https://github.com/user-attachments/assets/7e11e57b-053a-408b-a045-1e6adc76aa2b" />
