### PR TITLE
fix: 대소문자 구분 없이 학과 이름을 검색할 수 있도록 수정

### DIFF
--- a/src/components/DepartmentInput.tsx
+++ b/src/components/DepartmentInput.tsx
@@ -18,7 +18,9 @@ const DepartmentInput = ({ onNext, initialValue }: DepartmentInputProps) => {
     const value = event.target.value.trim();
     setDepartment(value);
 
-    const matches = departments.filter((dept) => value !== '' && dept.includes(value));
+    const matches = departments.filter(
+      (dept) => value !== '' && dept.toLowerCase().includes(value.toLowerCase()),
+    );
     setMatchingDepartments(matches);
   };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolve #38 

## 📝작업 내용
- 대소문자 구분 없이 학과 이름을 검색할 수 있도록 수정했습니다. (AI 융합학부 -> ai로 검색됨)

https://github.com/user-attachments/assets/7367d36c-be83-4a31-b6a9-cbd3624e254a

