### PR TITLE
fix: 시간표 템플릿이 여러개 보이는 버그

### DIFF
--- a/src/components/Timetable.tsx
+++ b/src/components/Timetable.tsx
@@ -19,7 +19,7 @@ const TIME_TABLE_COLOR = [
 ];
 
 const TIME_TABLE_TAG: Record<TimetableTag, string> = {
-  DEFAULT: '기본 시간표',
+  DEFAULT: '🤔 뭔가 좋아보이는 시간표',
   HAS_FREE_DAY: '🥳 공강 날이 있는 시간표',
   NO_MORNING_CLASSES: '⏰ 아침 수업이 없는 시간표',
   NO_LONG_BREAKS: '🚀 우주 공강이 없는 시간표 ',

--- a/src/components/TimetableSharingTemplate.tsx
+++ b/src/components/TimetableSharingTemplate.tsx
@@ -174,7 +174,7 @@ const TimetableSharingTemplate = forwardRef<HTMLDivElement, TimetableSharingTemp
 
     return (
       <>
-        <div className="w-full flex-1 overflow-hidden px-5" ref={emblaRef}>
+        <div className="w-full overflow-hidden px-5" ref={emblaRef}>
           <div className="-ml-5 flex">
             {TEMPLATE_COLORS.map((color, index) => (
               <div key={`template-${index}`} className="min-w-0 flex-[0_0_100%] transform-gpu pl-5">

--- a/src/components/TimetableSharingTemplate.tsx
+++ b/src/components/TimetableSharingTemplate.tsx
@@ -177,7 +177,7 @@ const TimetableSharingTemplate = forwardRef<HTMLDivElement, TimetableSharingTemp
         <div className="w-full flex-1 overflow-hidden px-5" ref={emblaRef}>
           <div className="-ml-5 flex">
             {TEMPLATE_COLORS.map((color, index) => (
-              <div key={`template-${index}`} className="min-w-0 flex-shrink-0 transform-gpu pl-5">
+              <div key={`template-${index}`} className="min-w-0 flex-[0_0_100%] transform-gpu pl-5">
                 <Template
                   bgImage={color.templateBg}
                   ref={selectedIndex === index ? templateRef : null}

--- a/src/pages/TimetableSelectionActivity.tsx
+++ b/src/pages/TimetableSelectionActivity.tsx
@@ -109,8 +109,8 @@ const TimetableSelectionActivity: ActivityComponentType = () => {
       title: '찾지 못했어요..',
       buttonText: '다시 만들기',
       element: () => (
-        <div className="flex flex-1 flex-col justify-center">
-          <img src={Warning} alt="Warning" />
+        <div className="flex flex-1 flex-col items-center justify-center">
+          <img src={Warning} alt="Warning" className="size-42.5" />
         </div>
       ),
     },

--- a/src/pages/TimetableSharingActivity.tsx
+++ b/src/pages/TimetableSharingActivity.tsx
@@ -81,7 +81,7 @@ const TimetableSharingActivity: ActivityComponentType<TimetableSharingParams> = 
     <AppScreen>
       <div className="flex min-h-dvh flex-col py-6">
         <AppBar progress={100} />
-        <div className="mt-6 flex flex-1 flex-col items-center">
+        <div className="mt-6 flex flex-1 flex-col items-center justify-evenly">
           <Suspense fallback={<TemplateSkeleton />}>
             <TimetableSharingTemplate timetableId={timetableId} ref={templateRef} />
             <div className="mt-4 flex justify-center gap-2">


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolve #53 

## 📝작업 내용
- 큰 화면에서 시간표 공유 템플릿이 여러개 보이는 문제를 수정했습니다.

https://github.com/user-attachments/assets/30e20bad-3419-417d-bde7-157acafa17c6
