### PR TITLE
fix: 시간표 블록 `border-radius` 제거

### DIFF
--- a/src/components/Timetable.tsx
+++ b/src/components/Timetable.tsx
@@ -227,7 +227,7 @@ const Timetable = ({ children, timetable, className, ...props }: TimetableProps)
                       return (
                         <div
                           key={`${timetable.timetableId}-${course.courseName}-${courseTime.start}`}
-                          className="absolute w-full rounded-lg p-0.5 text-xs font-bold text-white"
+                          className="absolute w-full p-0.5 text-xs font-bold text-white"
                           style={{
                             backgroundColor: bgColor,
                             borderColor: bgColor,


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolve #59 

## 📝작업 내용
- 시간표 블록의 `border-radius` 속성을 제거했습니다.

<img width="453" alt="image" src="https://github.com/user-attachments/assets/e03dde10-c227-4845-9bd8-e1eddaf4cad4" />
