### PR TITLE
refactor: 스크립트가 아닌 npm 모듈로 채널톡 SDK 연동

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           VITE_API_URL: ${{ secrets.VITE_API_URL }}
           VITE_MIXPANEL_TOKEN: ${{ secrets.VITE_MIXPANEL_TOKEN }}
+          VITE_CHANNEL_TALK_PLUGIN_KEY: ${{ secrets.VITE_CHANNEL_TALK_PLUGIN_KEY }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/index.html
+++ b/index.html
@@ -42,12 +42,6 @@
     />
   </head>
   <body>
-    <script>
-      (function(){var w=window;if(w.ChannelIO){return w.console.error("ChannelIO script included twice.");}var ch=function(){ch.c(arguments);};ch.q=[];ch.c=function(args){ch.q.push(args);};w.ChannelIO=ch;function l(){if(w.ChannelIOInitialized){return;}w.ChannelIOInitialized=true;var s=document.createElement("script");s.type="text/javascript";s.async=true;s.src="https://cdn.channel.io/plugin/ch-plugin-web.js";var x=document.getElementsByTagName("script")[0];if(x.parentNode){x.parentNode.insertBefore(s,x);}}if(document.readyState==="complete"){l();}else{w.addEventListener("DOMContentLoaded",l);w.addEventListener("load",l);}})();
-      ChannelIO('boot', {
-        "pluginKey": "00974094-3eae-441f-91e4-7f3404f44380"
-      });
-    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@channel.io/channel-web-sdk-loader": "^2.0.0",
     "@radix-ui/react-popover": "^1.1.5",
     "@radix-ui/react-toast": "^1.2.6",
     "@stackflow/core": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@channel.io/channel-web-sdk-loader':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@radix-ui/react-popover':
         specifier: ^1.1.5
         version: 1.1.5(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -227,6 +230,9 @@ packages:
   '@babel/types@7.26.5':
     resolution: {integrity: sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==}
     engines: {node: '>=6.9.0'}
+
+  '@channel.io/channel-web-sdk-loader@2.0.0':
+    resolution: {integrity: sha512-Z8DDpf2lAaYr/3aAnwQtxg0L8MYWgi/hhGV8c5/SLCV6Fx5Gssj7mfyHHrCVC315B0icmLYqZsXBlmbf6cN8Jg==}
 
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
@@ -2327,6 +2333,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@channel.io/channel-web-sdk-loader@2.0.0': {}
 
   '@emotion/hash@0.9.2': {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
 import { useEffect } from 'react';
 import { StudentMachineContext } from './machines/studentMachine';
 import { Stack } from './stackflow';
+import { ChannelTalk } from './utils/channelTalk';
 import { Mixpanel } from './utils/mixpanel';
 
 const App = () => {
   useEffect(() => {
-    // MixPanel에 사용자 식별
+    // MixPanel 사용자 식별
     Mixpanel.identify();
+    // ChannelTalk 채팅 초기화
+    ChannelTalk.boot();
   }, []);
 
   return (

--- a/src/utils/channelTalk.ts
+++ b/src/utils/channelTalk.ts
@@ -1,0 +1,11 @@
+import * as ChannelService from '@channel.io/channel-web-sdk-loader';
+
+ChannelService.loadScript();
+
+export const ChannelTalk = {
+  boot: () => {
+    ChannelService.boot({
+      pluginKey: import.meta.env.VITE_CHANNEL_TALK_PLUGIN_KEY,
+    });
+  },
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolved #71 

## 📝작업 내용
- 스크립트가 아닌 npm 모둘로 채널톡 SDK를 연동했습니다.
  - 채널톡 플러그인 키도 환경 변수로 옮김
