### PR TITLE
feat: Mixpanel 에러 로깅 및 세션 기록 추가

### DIFF
--- a/src/pages/TimetableSelectionActivity.tsx
+++ b/src/pages/TimetableSelectionActivity.tsx
@@ -67,7 +67,9 @@ const TimetableSelectionActivity: ActivityComponentType = () => {
   // Mixpanel 이벤트 추적
   useEffect(() => {
     if (latestMutation.status === 'error') {
-      Mixpanel.trackTimetableSelectionError();
+      if (latestMutation.error) {
+        Mixpanel.trackTimetableSelectionError(latestMutation.error);
+      }
     }
   }, [latestMutation]);
 

--- a/src/utils/mixpanel.ts
+++ b/src/utils/mixpanel.ts
@@ -12,6 +12,7 @@ mixpanel.init(MIXPANEL_TOKEN, {
   track_pageview: 'url-with-path',
   persistence: 'localStorage',
   ignore_dnt: true,
+  record_sessions_percent: 100,
 });
 
 export const Mixpanel = {

--- a/src/utils/mixpanel.ts
+++ b/src/utils/mixpanel.ts
@@ -1,4 +1,5 @@
 import mixpanel from 'mixpanel-browser';
+import { SoongptError } from '../schemas/errorSchema';
 import { CoursePreference, Student } from '../schemas/studentSchema';
 import { Timetable } from '../schemas/timetableSchema';
 import { CourseType } from '../type/course.type';
@@ -56,8 +57,10 @@ export const Mixpanel = {
     });
   },
 
-  trackTimetableSelectionError: () => {
-    mixpanel.track('Timetable Selection Error');
+  trackTimetableSelectionError: (error: SoongptError) => {
+    mixpanel.track('Timetable Selection Error', {
+      error,
+    });
   },
 
   trackTimetableSharingEnter: (timetable: Timetable) => {


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolved #67 

## 📝작업 내용
- 시간표 선택 과정에서 에러 발생 시 Mixpanel에 에러 로깅
- [Session Replay](https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript#session-replay) 기능 추가

