### PR TITLE
fix: 분반의 교수님 이름이 모두 표시되도록 수정

### DIFF
--- a/src/pages/CourseSelectionActivity/components/CourseSelectionList.tsx
+++ b/src/pages/CourseSelectionActivity/components/CourseSelectionList.tsx
@@ -1,11 +1,11 @@
-import { uniqBy } from 'es-toolkit';
 import { motion } from 'motion/react';
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
 
 import { SelectableCourseItem } from '@/components/CourseItem/SelectableCourseItem';
+import { useCombinedCourses } from '@/hooks/useCombinedCourses';
 import { SelectedCoursesContext } from '@/pages/CourseSelectionActivity/context';
 import { Course } from '@/schemas/courseSchema';
-import { extractComparableCourseCode, isSameCourse } from '@/utils/course';
+import { isSameCourse } from '@/utils/course';
 
 interface CourseSelectionListProps {
   courses: Course[];
@@ -13,8 +13,7 @@ interface CourseSelectionListProps {
 
 export const CourseSelectionList = ({ courses }: CourseSelectionListProps) => {
   const { selectedCourses, setSelectedCourses } = useContext(SelectedCoursesContext);
-
-  const uniqueCourses = useMemo(() => uniqBy(courses, extractComparableCourseCode), [courses]);
+  const uniqueCourses = useCombinedCourses(courses);
 
   return (
     <motion.div


### PR DESCRIPTION
## #️⃣연관된 이슈

- [교수님 이름이 하나만 나오는 문제](https://www.notion.so/yourssu/23f6915d6978806381b0f69c4d467465?source=copy_link)

## 📝작업 내용

- 분반의 교수님 이름이 모두 표시되도록 `useCombinedCourses()` 훅을 사용해 과목의 중복을 제거하도록 수정했어요.
<img width="300" alt="localhost_5173_(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/26652143-0ec3-4298-b7da-2ccc0271d218" />


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
